### PR TITLE
Ensure all files are correctly published.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "homepage": "http://github.com/the-economist-editorial/standard-server",
   "bugs": "http://github.com/the-economist-editorial/standard-server/issues",
   "main": "standard-server.js",
+  "files": [
+    "*.js",
+    "*.es6"
+  ],
   "babel": {
     "stage": 1,
     "loose": "all",


### PR DESCRIPTION
Unfortunately, npm uses `.gitignore` by default, as config of which
files to deploy and which to not. Anything listed in the
`.gitignore` will not be published. We obviously have `*.js` in our
`.gitignore` as we write `.es6` code.

Adding a `files` directive to our package.json tells npm to
specifically include particular files, overriding the contents of
`.gitignore`.